### PR TITLE
Fix "Unknown Location" in WOL, again

### DIFF
--- a/alerts.php
+++ b/alerts.php
@@ -8,9 +8,7 @@ define('THIS_SCRIPT', 'alerts.php');
 
 $templatelist = 'myalerts_alert_row_popup,myalerts_alert_row_popup_no_alerts,myalerts_modal_content';
 
-if ($_GET['action'] == 'modal') {
-	defined('NO_ONLINE') or define('NO_ONLINE', 1);
-}
+defined('NO_ONLINE') or define('NO_ONLINE', 1);
 
 require_once __DIR__ . '/global.php';
 


### PR DESCRIPTION
The previous fix (6aaa838c87891a387bc21e1282e2c6ec5cb4afcc) introduces a bug and inconsistencies:

- Missing GET parameter check, this may cause an `undefined index` error. In fact, you can't open the alert page normally without facing the error. 
![image](https://user-images.githubusercontent.com/20620780/75129919-2de6be00-56fe-11ea-9ba3-7dcb114263db.png)

- `modal` is not using the `action` parameter anymore (17643861578e29755029425216bcdd0af74e72d2).

-  Why is it to only define `NO_ONLINE` on `modal`? Opening the alert settings page or any other `action` value still giving "Unknown Location".

Anyway, thanks for this amazing plugin!